### PR TITLE
Update OCI provider configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/.terraform.lock.hcl
-**/.terraform/
+**/.terraform*
 **/terraform.tfstate
 **/terraform.tfstate.*
 ansible/hosts.cfg

--- a/OCI/main.tf
+++ b/OCI/main.tf
@@ -1,5 +1,6 @@
 module "compartment" {
   source = "./modules/compartment"
+  compartment_name = var.compartment_name
 }
 
 module "vcn" {
@@ -40,6 +41,11 @@ module "instance" {
   vcn_subnet_id  = module.network.public_subnet_id
   public_key     = module.key.public_key
   private_key    = module.key.private_key
+  shape          = var.shape
+  shape_config_memory_in_gbs = var.shape_config_memory_in_gbs
+  shape_config_ocpus         = var.shape_config_ocpus
+  availability_domain        = var.availability_domain
+  image_tag                  = var.image_tag
 
   depends_on = [module.vcn, module.network, module.key]
 }

--- a/OCI/modules/compartment/variables.tf
+++ b/OCI/modules/compartment/variables.tf
@@ -1,4 +1,2 @@
 variable "compartment_name" {
-  type    = string
-  default = "wireguard"
 }

--- a/OCI/modules/instance/main.tf
+++ b/OCI/modules/instance/main.tf
@@ -3,7 +3,7 @@ data "oci_identity_availability_domains" "ads" {
 }
 
 resource "oci_core_instance" "wirevpn_ci" {
-  availability_domain      = data.oci_identity_availability_domains.ads.availability_domains[1].name
+  availability_domain      = data.oci_identity_availability_domains.ads.availability_domains[var.availability_domain].name
   compartment_id           = var.compartment_id
   shape                    = var.shape
   shape_config {

--- a/OCI/modules/instance/variables.tf
+++ b/OCI/modules/instance/variables.tf
@@ -1,27 +1,26 @@
-variable "compartment_id" {}
-
-variable "image_tag" {
-  type    = string
-  default = "ocid1.image.oc1.iad.aaaaaaaatepknur5eq4oo2gyfi37dcohen6cxwtanuuhiqplakmco2bl4jia"
+variable "compartment_id" {
 }
 
 variable "shape" {
-  type    = string
-  default = "VM.Standard.E2.1.Micro"
 }
 
 variable "shape_config_ocpus" {
-  type    = number
-  default = 1
 }
 
 variable "shape_config_memory_in_gbs" {
-  type    = number
-  default = 1
 }
 
-variable "vcn_subnet_id" {}
+variable "vcn_subnet_id" {
+}
 
-variable "public_key" {}
+variable "public_key" {
+}
 
-variable "private_key" {}
+variable "private_key" {
+}
+
+variable "availability_domain" {
+}
+
+variable "image_tag" {
+}

--- a/OCI/modules/key/variables.tf
+++ b/OCI/modules/key/variables.tf
@@ -1,1 +1,2 @@
-variable "key_name" {}
+variable "key_name" {
+}

--- a/OCI/modules/network/variables.tf
+++ b/OCI/modules/network/variables.tf
@@ -1,5 +1,8 @@
-variable "compartment_id" {}
+variable "compartment_id" {
+}
 
-variable "vcn_id" {}
+variable "vcn_id" {
+}
 
-variable "ig_route_id" {}
+variable "ig_route_id" {
+}

--- a/OCI/variables.tf
+++ b/OCI/variables.tf
@@ -1,6 +1,7 @@
 variable "region" {
-  type    = string
-  default = "us-ashburn-1"
+}
+
+variable "availability_domain" {
 }
 
 variable "key_name" {
@@ -21,4 +22,29 @@ variable "vcn_name" {
 variable "vcn_dns_label" {
   type    = string
   default = "dnswirevcn"
+}
+
+variable "compartment_name" {
+  type    = string
+  default = "wireguard"
+}
+
+variable "shape" {
+  type    = string
+  default = "VM.Standard.E2.1.Micro"
+}
+
+variable "shape_config_ocpus" {
+  type    = number
+  default = 1
+}
+
+variable "shape_config_memory_in_gbs" {
+  type    = number
+  default = 1
+}
+
+variable "image_tag" {
+  type    = string
+  default = "ocid1.image.oc1.iad.aaaaaaaatepknur5eq4oo2gyfi37dcohen6cxwtanuuhiqplakmco2bl4jia"
 }

--- a/README.MD
+++ b/README.MD
@@ -64,9 +64,19 @@ export AWS_SECRET_ACCESS_KEY=
 ```
 * For OCI you need to configure your credentials using the following commands:
 ```bash
-oci session authenticate --region us-ashburn-1 # the region is the same as TF_VAR_region (default us-ashburn-1)
+sudo ~/bin/oci session authenticate --profile DEFAULT --region <region>
 export OCI_CLI_AUTH=security_token
+export TF_VAR_region="<region>"
+export TF_VAR_availability_domain=<availability_domain>  (A number between 1 and 3, according to the region)
 ```
+
+Run the Terraform commands whit `-E` to use the environment variables.
+
+```bash
+sudo terraform init
+sudo -E terraform apply
+```
+
 ## Tests - Checking the IP
 
 * Test the connection without VPN 

--- a/README.MD
+++ b/README.MD
@@ -67,7 +67,7 @@ export AWS_SECRET_ACCESS_KEY=
 sudo ~/bin/oci session authenticate --profile DEFAULT --region <region>
 export OCI_CLI_AUTH=security_token
 export TF_VAR_region="<region>"
-export TF_VAR_availability_domain=<availability_domain>  (A number between 1 and 3, according to the region)
+export TF_VAR_availability_domain=<availability_domain>  (A number between 0 and 2, according to the region)
 ```
 
 Run the Terraform commands whit `-E` to use the environment variables.


### PR DESCRIPTION
The declaration of the variable `availability_domain` with the number type enables the project to be used in accounts with limited resource availability. Free accounts have resource limitations based on availability domains (AD).

- README.md
[X] Modified the `oci session authenticate` command to use sudo in accordance with project requirements.
[X] Added `TF_VAR` for region and availability domains, making it easier to apply in other regions.
[X] Added instructions to run the `sudo terraform -E` command for the use of previously exported `TF_VAR`.

- modules/.../variables.tf
[X] Refactored for use with modules

- variables.tf
[X] Added the variable `availability_domain` and removed the `default` field in the `region` variable.
[X] Refactored for use with modules

- modules/instance/main.tf
[X] Implementation of the `availability_domain` variable.

- .gitignore
[X] Added `**/.terraform*` to the `.gitignore` file.